### PR TITLE
Fix: Components were not being displayed when publishing via github pages.

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build-vite": "tsc && vite build",
-    "deploy-storybook": "storybook-to-ghpages",
+    "deploy-storybook": "storybook-to-ghpages && touch ./storybook-static/.nojekyll",
     "build": "storybook build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "dev": "storybook dev -p 6006"


### PR DESCRIPTION
The reason of the error is that some of the js filenames start with underscore _, by default Github Pages won't host these files, even they present under the Github Page branch. We need to add a file called '.nojekyll' at root of the static folder.