### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Deploy storybook
         working-directory: ./packages/docs
-        run: npm run deploy-storybook -- --ci --existing-output-dir=storybook-static
+        run: touch storybook-static/.nojekyll && npm run deploy-storybook -- --ci --existing-output-dir=storybook-static
         env:
           GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build-vite": "tsc && vite build",
-    "deploy-storybook": "storybook-to-ghpages && touch ./storybook-static/.nojekyll",
+    "deploy-storybook": "storybook-to-ghpages",
     "build": "storybook build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "dev": "storybook dev -p 6006"


### PR DESCRIPTION
The reason of the error is that some of the js filenames start with underscore _, by default Github Pages won't host these files, even they present under the Github Page branch. We need to add a file called '.nojekyll' at root of the static folder.